### PR TITLE
Remove debug logging unless --debug is passed

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -3,6 +3,7 @@
 let
   cfg = config.services.openspatial;
   openspatial = pkgs.callPackage ./package.nix { };
+  args = lib.optionalString cfg.debug " --debug";
 in
 {
   options.services.openspatial = {
@@ -24,6 +25,12 @@ in
       type = lib.types.bool;
       default = false;
       description = "Open firewall port";
+    };
+
+    debug = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Enable debug logging";
     };
 
     dataDir = lib.mkOption {
@@ -118,11 +125,11 @@ in
             text = ''
               TURN_SECRET="$(cat ${cfg.turn.secretFile})"
               export TURN_SECRET
-              exec ${openspatial}/bin/openspatial
+              exec ${openspatial}/bin/openspatial${args}
             '';
           });
         } else {
-          ExecStart = "${openspatial}/bin/openspatial";
+          ExecStart = "${openspatial}/bin/openspatial${args}";
         });
       };
 

--- a/server/standalone.ts
+++ b/server/standalone.ts
@@ -13,6 +13,10 @@ import { runMigrations, ensureDemoSpace } from './db.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+// Parse command line arguments
+const args = process.argv.slice(2);
+const debug = args.includes('--debug');
+
 const app = express();
 const PORT = Number(process.env.PORT) || 3000;
 // HTTPS enabled by default, set HTTPS=0 to disable
@@ -86,10 +90,10 @@ const io = new Server(server, {
     pingInterval: 5000,    // Ping every 5s (default: 25000)
 });
 
-attachSignaling(io);
+attachSignaling(io, debug);
 
 // Attach Yjs WebSocket server for CRDT document synchronization
-attachYjsServer(server);
+attachYjsServer(server, debug);
 
 // Async startup: run migrations and ensure demo space before listening
 const protocol = USE_HTTPS ? 'https' : 'http';
@@ -101,6 +105,9 @@ const protocol = USE_HTTPS ? 'https' : 'http';
         
         server.listen(PORT, '0.0.0.0', () => {
             console.log(`🚀 OpenSpatial running on ${protocol}://0.0.0.0:${PORT}`);
+            if (debug) {
+                console.log('🐞 Debug logging enabled');
+            }
         });
     } catch (err) {
         console.error('Startup failed:', err);


### PR DESCRIPTION
This PR addresses issue #43 by reducing the verbosity of OpenSpatial server logs. 

Key changes:
- `server/standalone.ts`: Parses `--debug` command line argument.
- `server/signaling.ts`: Hides "CRDT Cleanup" and signal warning logs behind the debug flag. Keeps Peer Joined/Left/Deleted and Screen Share events visible.
- `server/yjs-server.ts`: Hides Yjs connection, hydration, destruction, and auto-creation logs behind the debug flag. Persistence logs are preserved if they signify updates.
- `nix/module.nix`: Adds a `debug` option (boolean) to the NixOS service, which passes `--debug` to the executable when enabled.

Tests verified:
- `npm run typecheck`: Passed.
- `npm run test`: Passed (Integration tests verify key events are still logged).

---
*PR created automatically by Jules for task [15571866039592218829](https://jules.google.com/task/15571866039592218829) started by @srid*