### PR TITLE
Fix flaky tests

### DIFF
--- a/e2e/dsl/user.ts
+++ b/e2e/dsl/user.ts
@@ -252,22 +252,24 @@ export class UserImpl implements User {
     const note = this.page.locator('.text-note').first();
     // Click the font size button to open menu
     const fontSizeBtn = note.locator('.text-note-font-size');
-    await fontSizeBtn.click({ force: true });
-    // Click the menu option with matching text
+    await fontSizeBtn.click();
+    // Wait for menu to render, then click option
     const sizeLabel = size.charAt(0).toUpperCase() + size.slice(1); // 'small' -> 'Small'
     const option = this.page.locator('.text-note-menu-option', { hasText: sizeLabel });
-    await option.click({ force: true });
+    await option.waitFor({ state: 'visible' });
+    await option.click();
   }
 
   async setTextNoteFontFamily(family: 'sans' | 'serif' | 'mono'): Promise<void> {
     const note = this.page.locator('.text-note').first();
     // Click the font family button to open menu
     const fontFamilyBtn = note.locator('.text-note-font-family');
-    await fontFamilyBtn.click({ force: true });
-    // Click the menu option with matching text
+    await fontFamilyBtn.click();
+    // Wait for menu to render, then click option
     const familyLabels: Record<string, string> = { sans: 'Sans', serif: 'Serif', mono: 'Mono' };
     const option = this.page.locator('.text-note-menu-option', { hasText: familyLabels[family] });
-    await option.click({ force: true });
+    await option.waitFor({ state: 'visible' });
+    await option.click();
   }
 
   async deleteTextNote(): Promise<void> {

--- a/e2e/dsl/views.ts
+++ b/e2e/dsl/views.ts
@@ -64,13 +64,12 @@ export class AvatarViewImpl implements AvatarView {
   }
 
   async status(): Promise<string | null> {
+    // Quick snapshot — use expect.poll() at the call site for cross-user sync waiting
     const statusEl = this.locator.locator('.avatar-status');
-    try {
-      await expect(statusEl).toBeVisible({ timeout: SYNC_TIMEOUT });
+    if (await statusEl.isVisible()) {
       return await statusEl.textContent();
-    } catch {
-      return null;
     }
+    return null;
   }
 
   async state(): Promise<AvatarState> {


### PR DESCRIPTION
## Changes

### Flaky test fixes
- **Font menu interactions** (`user.ts`): Removed `force: true` from menu clicks, added `waitFor({ state: 'visible' })` before clicking options
- **Status sync** (`views.ts`, `status.spec.ts`): Made `status()` a quick snapshot (no 5s internal wait) so it works correctly inside `expect.poll`; wrapped cross-user assertions in `expect.poll`
