### PR TITLE
Sound Effects: Restore join/leave chimes (fixes #67)

### DIFF
--- a/client/context/SpaceContext.tsx
+++ b/client/context/SpaceContext.tsx
@@ -13,6 +13,7 @@ import type { Awareness } from 'y-protocols/awareness';
 import type { PeerState, ScreenShareState, TextNoteState } from '../../shared/yjs-schema';
 import { getTextNoteText, createTextNoteObservers } from '../../shared/yjs-schema';
 import type { ConnectedEvent, SpaceInfoEvent, PeerJoinedEvent, PeerLeftEvent } from '../../shared/types/events';
+import { playJoinSound, playLeaveSound } from '../lib/sounds';
 
 export type View = 'landing' | 'join' | 'space' | 'not-found';
 export type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
@@ -653,6 +654,7 @@ export const SpaceProvider: ParentComponent = (props) => {
     // When a new peer joins, initiate connection
     onSocket<{ peerId: string; username: string }>('peer-joined', async (data) => {
       const { peerId } = data;
+      playJoinSound();
       const pc = createPeerConnection(peerId);
       
       // Add local webcam tracks
@@ -693,6 +695,7 @@ export const SpaceProvider: ParentComponent = (props) => {
     
     // When a peer leaves, close connection
     onSocket<{ peerId: string }>('peer-left', (data) => {
+      playLeaveSound();
       const pc = peerConnections.get(data.peerId);
       if (pc) {
         pc.close();

--- a/client/lib/sounds.ts
+++ b/client/lib/sounds.ts
@@ -1,0 +1,94 @@
+/**
+ * Sound Effects Module
+ *
+ * Provides audio feedback for key events like users joining or leaving a space.
+ * Uses Web Audio API's OscillatorNode to generate tones programmatically,
+ * avoiding the need for external audio files.
+ *
+ * Records played sounds to window.__openspatialSounds for E2E testability.
+ */
+
+declare global {
+  interface Window {
+    __openspatialSounds?: string[];
+  }
+}
+
+/** Audio context for generating notification sounds */
+let audioContext: AudioContext | null = null;
+
+/**
+ * Initialize the audio context lazily (requires user interaction first).
+ */
+function getAudioContext(): AudioContext {
+  if (!audioContext) {
+    audioContext = new AudioContext();
+  }
+  return audioContext;
+}
+
+/**
+ * Record a sound event for E2E test observability.
+ */
+function recordSound(name: string): void {
+  if (!window.__openspatialSounds) {
+    window.__openspatialSounds = [];
+  }
+  window.__openspatialSounds.push(name);
+}
+
+/**
+ * Play a simple tone using the Web Audio API.
+ */
+function playTone(
+  frequency: number,
+  duration: number,
+  type: OscillatorType = 'sine',
+  volumeMultiplier: number = 0.15
+): void {
+  try {
+    const ctx = getAudioContext();
+    if (ctx.state === 'suspended') {
+      ctx.resume();
+    }
+
+    const oscillator = ctx.createOscillator();
+    const gainNode = ctx.createGain();
+
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequency, ctx.currentTime);
+
+    // Envelope: quick attack, gradual decay for a pleasant sound
+    gainNode.gain.setValueAtTime(0, ctx.currentTime);
+    gainNode.gain.linearRampToValueAtTime(volumeMultiplier, ctx.currentTime + 0.02);
+    gainNode.gain.exponentialRampToValueAtTime(0.01, ctx.currentTime + duration / 1000);
+
+    oscillator.connect(gainNode);
+    gainNode.connect(ctx.destination);
+
+    oscillator.start(ctx.currentTime);
+    oscillator.stop(ctx.currentTime + duration / 1000);
+  } catch (e) {
+    // Silently ignore audio errors (e.g., in headless test environments)
+    console.debug('Audio notification failed:', e);
+  }
+}
+
+/**
+ * Play a "user joined" notification sound.
+ * Ascending two-note chime (C5 → E5).
+ */
+export function playJoinSound(): void {
+  recordSound('join');
+  playTone(523, 150, 'sine', 0.12); // C5
+  setTimeout(() => playTone(659, 200, 'sine', 0.1), 120); // E5
+}
+
+/**
+ * Play a "user left" notification sound.
+ * Soft descending tone (G4).
+ */
+export function playLeaveSound(): void {
+  recordSound('leave');
+  playTone(392, 200, 'sine', 0.08);
+}

--- a/e2e/dsl/types.ts
+++ b/e2e/dsl/types.ts
@@ -110,6 +110,9 @@ export interface User {
   closeActivityPanel(): Promise<void>;
   activityItems(): Promise<ActivityItem[]>;
   isActivityBadgeVisible(): Promise<boolean>;
+
+  // Sound effects
+  soundsPlayed(): Promise<string[]>;
 }
 
 export interface AvatarView {

--- a/e2e/dsl/user.ts
+++ b/e2e/dsl/user.ts
@@ -531,4 +531,8 @@ export class UserImpl implements User {
     const badge = this.page.locator('#activity-badge');
     return !(await badge.evaluate((el) => el.classList.contains('hidden')));
   }
+
+  async soundsPlayed(): Promise<string[]> {
+    return this.page.evaluate(() => (window as any).__openspatialSounds ?? []);
+  }
 }

--- a/e2e/scenarios/sound.spec.ts
+++ b/e2e/scenarios/sound.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * Sound Effect Scenarios
+ */
+import { expect } from '@playwright/test';
+import { scenario } from '../dsl';
+
+scenario('join sound plays when peer joins', 'sound-join', async ({ createUser }) => {
+  const alice = await createUser('Alice').join();
+  const bob = await createUser('Bob').join();
+  await alice.waitForUser('Bob');
+
+  // Alice should have heard a join sound when Bob appeared
+  await expect.poll(async () => {
+    const sounds = await alice.soundsPlayed();
+    return sounds.includes('join');
+  }, { timeout: 5000 }).toBe(true);
+});
+
+scenario('leave sound plays when peer leaves', 'sound-leave', async ({ createUser }) => {
+  const alice = await createUser('Alice').join();
+  const bob = await createUser('Bob').join();
+  await alice.waitForUser('Bob');
+
+  await bob.leave();
+
+  // Alice should hear a leave sound when Bob departs
+  await expect.poll(async () => {
+    const sounds = await alice.soundsPlayed();
+    return sounds.includes('leave');
+  }, { timeout: 5000 }).toBe(true);
+});


### PR DESCRIPTION
## Summary

Restore join/leave notification chimes that were lost in the SolidJS migration (PR #48).

Uses Web Audio API (`OscillatorNode` + `GainNode`) to synthesize tones — no audio file assets needed.

Closes #67

## Changes

| File | Change |
|------|--------|
| `client/lib/sounds.ts` | **New** — `playJoinSound()` (ascending C5→E5 chime) and `playLeaveSound()` (descending G4 tone) |
| `client/context/SpaceContext.tsx` | Call sound functions in `peer-joined` / `peer-left` socket handlers |
| `e2e/dsl/types.ts` | Added `soundsPlayed()` to `User` interface |
| `e2e/dsl/user.ts` | Implemented `soundsPlayed()` — reads `window.__openspatialSounds` |
| `e2e/scenarios/sound.spec.ts` | **New** — 2 E2E tests verify join/leave sounds fire |

## Verification

- ✅ `tsc --noEmit` — clean
- ✅ `just e2e-quick "sound"` — 2 passed (6.1s)
- ✅ Manual test: heard chimes when joining/leaving in two browser tabs
