### PR TITLE
Extract useDraggable hook (DRY: TextNote + ScreenShare drag logic)

### DIFF
--- a/client/components/Canvas/ScreenShare.tsx
+++ b/client/components/Canvas/ScreenShare.tsx
@@ -5,6 +5,7 @@
  */
 import { Component, createMemo, Show, createSignal, onMount, onCleanup, createEffect } from 'solid-js';
 import { useSpace } from '@/context/SpaceContext';
+import { useDraggable } from '@/hooks/useDraggable';
 import { useResizable } from '@/hooks/useResizable';
 import { CloseButton } from './CloseButton';
 
@@ -19,20 +20,15 @@ export const ScreenShare: Component<ScreenShareProps> = (props) => {
   let headerRef: HTMLDivElement | undefined;
   let videoRef: HTMLVideoElement | undefined;
   
-  // Use refs for drag state to avoid reactive updates
-  let dragState = {
-    isDragging: false,
-    startX: 0,
-    startY: 0,
-    initialX: 0,
-    initialY: 0,
-  };
-  
-  const [isDraggingSignal, setIsDraggingSignal] = createSignal(false);
   const [copySuccess, setCopySuccess] = createSignal(false);
   
   const share = createMemo(() => ctx.screenShares().get(props.shareId));
   const stream = createMemo(() => ctx.screenShareStreams().get(props.shareId));
+  
+  const draggable = useDraggable({
+    position: () => ({ x: share()?.x ?? 0, y: share()?.y ?? 0 }),
+    onMove: (x, y) => ctx.updateScreenSharePosition(props.shareId, x, y),
+  });
   
   // Resizable hook for consistent resize behavior
   const resizable = useResizable({
@@ -62,62 +58,12 @@ export const ScreenShare: Component<ScreenShareProps> = (props) => {
   
   onMount(() => {
     if (containerRef && headerRef) {
-      setupDrag();
+      draggable.setup(headerRef);
       resizable.setup(containerRef);
-      
-      // Listen for test-resize events from e2e tests
-      containerRef.addEventListener('test-resize', ((e: CustomEvent) => {
-        const { width, height } = e.detail;
-        ctx.updateScreenShareSize(props.shareId, width, height);
-      }) as EventListener);
     }
   });
   
-  function setupDrag() {
-    if (!headerRef) return;
-    
-    const handleMouseDown = (e: MouseEvent) => {
-      e.stopPropagation();
-      e.preventDefault();
-      
-      const s = share();
-      if (!s) return;
-      
-      dragState.isDragging = true;
-      dragState.startX = e.clientX;
-      dragState.startY = e.clientY;
-      dragState.initialX = s.x;
-      dragState.initialY = s.y;
-      setIsDraggingSignal(true);
-    };
-    
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!dragState.isDragging) return;
-      e.preventDefault();
-      
-      const deltaX = e.clientX - dragState.startX;
-      const deltaY = e.clientY - dragState.startY;
-      
-      ctx.updateScreenSharePosition(props.shareId, dragState.initialX + deltaX, dragState.initialY + deltaY);
-    };
-    
-    const handleMouseUp = () => {
-      if (dragState.isDragging) {
-        dragState.isDragging = false;
-        setIsDraggingSignal(false);
-      }
-    };
-    
-    headerRef.addEventListener('mousedown', handleMouseDown);
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-    
-    onCleanup(() => {
-      headerRef?.removeEventListener('mousedown', handleMouseDown);
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-    });
-  }
+
   
   // Resize is handled by useResizable hook
   

--- a/client/components/Canvas/TextNote.tsx
+++ b/client/components/Canvas/TextNote.tsx
@@ -5,6 +5,7 @@
  */
 import { Component, createMemo, Show, createSignal, onMount, onCleanup, createEffect, For } from 'solid-js';
 import { useSpace } from '@/context/SpaceContext';
+import { useDraggable } from '@/hooks/useDraggable';
 import { useResizable } from '@/hooks/useResizable';
 import { CollabEditor } from './CollabEditor';
 import { CloseButton } from './CloseButton';
@@ -31,19 +32,15 @@ export const TextNote: Component<TextNoteProps> = (props) => {
   let containerRef: HTMLDivElement | undefined;
   let headerRef: HTMLDivElement | undefined;
   
-  // Use plain object refs for drag state to avoid reactivity issues
-  const dragState = {
-    isDragging: false,
-    startX: 0,
-    startY: 0,
-    initialX: 0,
-    initialY: 0,
-  };
-  
-  const [isDraggingSignal, setIsDraggingSignal] = createSignal(false);
   const [showFontSizeMenu, setShowFontSizeMenu] = createSignal(false);
   const [showFontFamilyMenu, setShowFontFamilyMenu] = createSignal(false);
 
+  const note = createMemo(() => ctx.textNotes().get(props.noteId));
+  
+  const draggable = useDraggable({
+    position: () => ({ x: note()?.x ?? 0, y: note()?.y ?? 0 }),
+    onMove: (x, y) => ctx.updateTextNotePosition(props.noteId, x, y),
+  });
   
   // Resizable hook for consistent resize behavior
   const resizable = useResizable({
@@ -54,69 +51,14 @@ export const TextNote: Component<TextNoteProps> = (props) => {
     minHeight: 150,
   });
   
-  const note = createMemo(() => ctx.textNotes().get(props.noteId));
-  
   onMount(() => {
     if (containerRef && headerRef) {
-      setupDrag();
+      draggable.setup(headerRef);
       resizable.setup(containerRef);
-      
-      // Listen for test-resize events from e2e tests
-      containerRef.addEventListener('test-resize', ((e: CustomEvent) => {
-        const { width, height } = e.detail;
-        ctx.updateTextNoteSize(props.noteId, width, height);
-      }) as EventListener);
     }
   });
   
-  function setupDrag() {
-    if (!headerRef) return;
-    
-    const handleMouseDown = (e: MouseEvent) => {
-      // Don't drag if clicking on a button
-      if ((e.target as HTMLElement).closest('button')) return;
-      
-      e.stopPropagation();
-      e.preventDefault();
-      
-      const n = note();
-      if (!n) return;
-      
-      dragState.isDragging = true;
-      dragState.startX = e.clientX;
-      dragState.startY = e.clientY;
-      dragState.initialX = n.x;
-      dragState.initialY = n.y;
-      setIsDraggingSignal(true);
-    };
-    
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!dragState.isDragging) return;
-      e.preventDefault();
-      
-      const deltaX = e.clientX - dragState.startX;
-      const deltaY = e.clientY - dragState.startY;
-      
-      ctx.updateTextNotePosition(props.noteId, dragState.initialX + deltaX, dragState.initialY + deltaY);
-    };
-    
-    const handleMouseUp = () => {
-      if (dragState.isDragging) {
-        dragState.isDragging = false;
-        setIsDraggingSignal(false);
-      }
-    };
-    
-    headerRef.addEventListener('mousedown', handleMouseDown);
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-    
-    onCleanup(() => {
-      headerRef?.removeEventListener('mousedown', handleMouseDown);
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-    });
-  }
+
   
   function handleFontSizeClick(e: MouseEvent) {
     e.stopPropagation();

--- a/client/hooks/useDraggable.ts
+++ b/client/hooks/useDraggable.ts
@@ -1,0 +1,79 @@
+/**
+ * useDraggable Hook
+ * Provides consistent drag behavior for draggable elements via a header/handle.
+ * Uses refs for drag state to avoid reactive updates during drag.
+ */
+import { createSignal, onCleanup, Accessor } from 'solid-js';
+
+export interface DragConfig {
+  /** Accessor returning current position */
+  position: Accessor<{ x: number; y: number }>;
+  /** Callback when element is dragged to a new position */
+  onMove: (x: number, y: number) => void;
+}
+
+export interface DragResult {
+  /** Signal indicating if currently dragging */
+  isDragging: Accessor<boolean>;
+  /** Setup function to call in onMount with header/handle ref */
+  setup: (headerRef: HTMLElement) => void;
+}
+
+export function useDraggable(config: DragConfig): DragResult {
+  const [isDragging, setIsDragging] = createSignal(false);
+
+  let dragState = {
+    isDragging: false,
+    startX: 0,
+    startY: 0,
+    initialX: 0,
+    initialY: 0,
+  };
+
+  function setup(headerRef: HTMLElement) {
+    const handleMouseDown = (e: MouseEvent) => {
+      // Don't drag if clicking on a button
+      if ((e.target as HTMLElement).closest('button')) return;
+
+      e.stopPropagation();
+      e.preventDefault();
+
+      const pos = config.position();
+      dragState.isDragging = true;
+      dragState.startX = e.clientX;
+      dragState.startY = e.clientY;
+      dragState.initialX = pos.x;
+      dragState.initialY = pos.y;
+      setIsDragging(true);
+    };
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!dragState.isDragging) return;
+      e.preventDefault();
+
+      const deltaX = e.clientX - dragState.startX;
+      const deltaY = e.clientY - dragState.startY;
+
+      config.onMove(dragState.initialX + deltaX, dragState.initialY + deltaY);
+    };
+
+    const handleMouseUp = () => {
+      if (dragState.isDragging) {
+        dragState.isDragging = false;
+        setIsDragging(false);
+      }
+    };
+
+    headerRef.addEventListener('mousedown', handleMouseDown);
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+
+    onCleanup(() => {
+      headerRef.removeEventListener('mousedown', handleMouseDown);
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    });
+  }
+
+  return { isDragging, setup };
+}

--- a/client/hooks/useResizable.tsx
+++ b/client/hooks/useResizable.tsx
@@ -47,6 +47,11 @@ export function useResizable(config: ResizeConfig): ResizeResult {
   };
   
   function setup(containerRef: HTMLElement) {
+    // Listen for test-resize events from e2e tests
+    containerRef.addEventListener('test-resize', ((e: CustomEvent) => {
+      config.onResize(e.detail.width, e.detail.height);
+    }) as EventListener);
+    
     const resizeHandle = containerRef.querySelector('.resize-handle-se') as HTMLElement;
     if (!resizeHandle) return;
     

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@ openspatial/
 │   ├── components/
 │   │   ├── Canvas/             # Avatar, Canvas, ScreenShare, TextNote
 │   │   └── Controls/           # ControlBar, ActivityPanel
-│   └── hooks/                  # useLocalMedia, useResizable
+│   └── hooks/                  # useDraggable, useLocalMedia, useResizable
 │
 ├── server/                     # Node.js Backend
 │   ├── main.ts                 # Unified server entry (dev + prod)


### PR DESCRIPTION
Closes #73

## Changes

- **New `client/hooks/useDraggable.ts`** — reusable hook accepting `position` accessor + `onMove` callback, managing drag state refs, `isDragging` signal, and mouse event listeners with cleanup
- **Refactored `TextNote.tsx`** — replaced ~48-line `setupDrag()` with 3-line `useDraggable` call
- **Refactored `ScreenShare.tsx`** — same, replaced ~45-line `setupDrag()` with `useDraggable`
- **Folded `test-resize` into `useResizable`** — both components had identical 4-line `test-resize` event listeners, now handled inside `useResizable.setup()`
- **Updated `ARCHITECTURE.md`** — hooks listing now includes `useDraggable`

Net: **+102 / -130 lines** (28 lines removed overall)

## Testing

All 78 e2e tests pass via `just e2e-quick`.
