### PR TITLE
Fix duplicate Slack notifications on deployment

### DIFF
--- a/server/database/types.ts
+++ b/server/database/types.ts
@@ -34,10 +34,21 @@ export interface SpaceEventsTable {
 }
 
 
+// Persisted live notification messages (survives server restarts)
+export interface LiveMessagesTable {
+  space_id: string;
+  message_id: string;
+  username: string;
+  join_url: string;
+  started_at: number;
+  backend: string;
+}
+
 export interface Database {
   spaces: SpacesTable;
   text_elements: TextElementsTable;
   space_events: SpaceEventsTable;
+  live_messages: LiveMessagesTable;
 }
 
 export type Space = Selectable<SpacesTable>;

--- a/server/db.ts
+++ b/server/db.ts
@@ -229,3 +229,45 @@ export async function getRecentActivity(spaceId: string): Promise<SpaceEvent[]> 
     .execute();
   return rows;
 }
+
+// === Live Message Operations (notification persistence) ===
+
+export interface LiveMessageRow {
+  space_id: string;
+  message_id: string;
+  username: string;
+  join_url: string;
+  started_at: number;
+  backend: string;
+}
+
+export async function saveLiveMessage(row: LiveMessageRow): Promise<void> {
+  await db
+    .insertInto('live_messages')
+    .values(row)
+    .onConflict((oc) =>
+      oc.column('space_id').doUpdateSet({
+        message_id: row.message_id,
+        username: row.username,
+        join_url: row.join_url,
+        started_at: row.started_at,
+        backend: row.backend,
+      })
+    )
+    .execute();
+}
+
+export async function deleteLiveMessage(spaceId: string): Promise<void> {
+  await db
+    .deleteFrom('live_messages')
+    .where('space_id', '=', spaceId)
+    .execute();
+}
+
+export async function getAllLiveMessages(): Promise<LiveMessageRow[]> {
+  return await db
+    .selectFrom('live_messages')
+    .selectAll()
+    .execute();
+}
+

--- a/server/main.ts
+++ b/server/main.ts
@@ -74,7 +74,7 @@ const protocol = config.https ? 'https' : 'http';
     initDb(config);
     await runMigrations();
     await ensureDemoSpace(config);
-    initNotifier(config);
+    await initNotifier(config);
 
     if (isDev) {
       // Dev mode: Vite handles client assets & HMR, Hono handles API routes

--- a/server/migrations/0004_live_messages.ts
+++ b/server/migrations/0004_live_messages.ts
@@ -1,0 +1,23 @@
+/**
+ * Migration: Add live_messages table
+ *
+ * Persists active Slack notification state so that on server restart,
+ * orphaned LIVE messages can be updated to ENDED.
+ */
+import { Kysely } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable('live_messages')
+    .addColumn('space_id', 'text', (col) => col.primaryKey())
+    .addColumn('message_id', 'text', (col) => col.notNull())
+    .addColumn('username', 'text', (col) => col.notNull())
+    .addColumn('join_url', 'text', (col) => col.notNull())
+    .addColumn('started_at', 'integer', (col) => col.notNull())
+    .addColumn('backend', 'text', (col) => col.notNull())
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('live_messages').execute();
+}

--- a/server/notifier/index.ts
+++ b/server/notifier/index.ts
@@ -3,10 +3,14 @@
  *
  * Live message tracking: maps spaceId -> { messageId, startedAt } for
  * updating the Slack message when the space becomes inactive.
+ *
+ * Live messages are persisted to SQLite so that on server restart,
+ * orphaned LIVE messages are updated to ENDED before new connections arrive.
  */
 import type { NotificationBackend, NotifierConfig, SpaceNotification } from './types.js';
 import { SlackBackend } from './slack.js';
 import type { ServerConfig } from '../config.js';
+import { saveLiveMessage, deleteLiveMessage, getAllLiveMessages } from '../db.js';
 
 let notifierConfig: NotifierConfig | null = null;
 
@@ -27,8 +31,9 @@ const liveMessages = new Map<string, LiveMessage>();
 
 /**
  * Initialize the notifier system from server config.
+ * Also recovers any orphaned live messages from a previous server instance.
  */
-export function initNotifier(config: ServerConfig): void {
+export async function initNotifier(config: ServerConfig): Promise<void> {
   const backends: NotificationBackend[] = [];
   
   // Initialize Slack backend if configured
@@ -55,11 +60,50 @@ export function initNotifier(config: ServerConfig): void {
   
   const spacesInfo = config.slack.spaces ? `spaces: [${config.slack.spaces.join(', ')}]` : 'all spaces';
   console.log(`[Notifier] Initialized with ${backends.length} backend(s), ${spacesInfo}`);
+
+  // Recover orphaned live messages from previous server instance
+  await recoverLiveMessages(backends);
+}
+
+/**
+ * Close out any live messages left over from a previous server process.
+ * Each orphaned LIVE message is updated to ENDED and removed from the DB.
+ */
+async function recoverLiveMessages(backends: NotificationBackend[]): Promise<void> {
+  const orphaned = await getAllLiveMessages();
+  if (orphaned.length === 0) return;
+
+  console.log(`[Notifier] Recovering ${orphaned.length} orphaned live message(s) from previous instance`);
+
+  for (const row of orphaned) {
+    const backend = backends.find((b) => b.name === row.backend);
+    if (!backend) {
+      console.warn(`[Notifier] No backend '${row.backend}' available to close orphaned message for space ${row.space_id}`);
+      await deleteLiveMessage(row.space_id);
+      continue;
+    }
+
+    const durationMs = Date.now() - row.started_at;
+    try {
+      await backend.notifySpaceInactive({
+        messageId: row.message_id,
+        spaceId: row.space_id,
+        username: row.username,
+        joinUrl: row.join_url,
+        durationMs,
+      });
+      console.log(`[Notifier] Closed orphaned LIVE message for space ${row.space_id}`);
+    } catch (error) {
+      console.error(`[Notifier] Error closing orphaned message for ${row.space_id}:`, error);
+    }
+
+    await deleteLiveMessage(row.space_id);
+  }
 }
 
 /**
  * Notify that a space became active (first user joined).
- * Stores the returned message ID for later updates.
+ * Stores the returned message ID for later updates (in-memory + DB).
  */
 export async function notifySpaceActive(spaceId: string, username: string): Promise<void> {
   if (!notifierConfig || notifierConfig.backends.length === 0) {
@@ -84,14 +128,25 @@ export async function notifySpaceActive(spaceId: string, username: string): Prom
       
       // Only track on successful send
       if (messageId) {
+        const startedAt = Date.now();
         console.log(`[Notifier] Live message posted for ${spaceId}`);
         
         liveMessages.set(spaceId, {
           messageId,
           username,
           joinUrl: notification.joinUrl,
-          startedAt: Date.now(),
+          startedAt,
           backend,
+        });
+
+        // Persist to DB for crash recovery
+        await saveLiveMessage({
+          space_id: spaceId,
+          message_id: messageId,
+          username,
+          join_url: notification.joinUrl,
+          started_at: startedAt,
+          backend: backend.name,
         });
       }
     } catch (error) {
@@ -124,6 +179,9 @@ export async function notifySpaceInactive(spaceId: string): Promise<void> {
   } catch (error) {
     console.error(`[Notifier] Error updating live message for ${spaceId}:`, error);
   }
+
+  // Remove from DB
+  await deleteLiveMessage(spaceId);
 }
 
 /**


### PR DESCRIPTION
Fixes #77

## Problem

When the server restarts (deployment), the in-memory `liveMessages` Map is lost. Reconnecting users trigger a new 🟢 LIVE Slack notification, while the old one stays dangling forever as LIVE.

## Solution

Persist live messages to SQLite. On startup, recover any orphaned live messages and update them to ⚫ ENDED before accepting new connections.

## Changes

- **New migration** `0004_live_messages.ts` — `live_messages` table keyed by `space_id`
- **`database/types.ts`** — `LiveMessagesTable` interface
- **`db.ts`** — `saveLiveMessage`, `deleteLiveMessage`, `getAllLiveMessages` CRUD
- **`notifier/index.ts`** — persist on write, `recoverLiveMessages()` on startup
- **`main.ts`** — `await initNotifier(config)` (now async for DB recovery)
