### PR TITLE
Allow media-less join (declined camera/mic)

### DIFF
--- a/client/components/Controls/ControlBar.tsx
+++ b/client/components/Controls/ControlBar.tsx
@@ -10,8 +10,8 @@ import { v4 as uuidv4 } from 'uuid';
 export const ControlBar: Component = () => {
   const ctx = useSpace();
   
-  const [isMuted, setIsMuted] = createSignal(false);
-  const [isVideoOff, setIsVideoOff] = createSignal(false);
+  const [isMuted, setIsMuted] = createSignal(ctx.session()?.localUser.isMuted ?? false);
+  const [isVideoOff, setIsVideoOff] = createSignal(ctx.session()?.localUser.isVideoOff ?? false);
   const [activityOpen, setActivityOpen] = createSignal(false);
   const [hasUnread, setHasUnread] = createSignal(false);
   
@@ -39,9 +39,55 @@ export const ControlBar: Component = () => {
     });
   });
   
-  function handleToggleMic() {
+  const [mediaError, setMediaError] = createSignal<string | null>(null);
+  
+  async function acquireStream(): Promise<MediaStream | null> {
+    setMediaError(null);
+    try {
+      const mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'user', width: { ideal: 640 }, height: { ideal: 480 } },
+        audio: true,
+      });
+      const user = localUser();
+      if (!user) return null;
+      
+      // Update session with the new stream
+      ctx.setSession({
+        ...ctx.session()!,
+        localUser: { ...user, stream: mediaStream, isMuted: false, isVideoOff: false },
+      });
+      
+      // Update CRDT state
+      ctx.updatePeerMediaState(user.peerId, false, false);
+      
+      // Send tracks to existing peers
+      await ctx.addLocalStreamToPeers(mediaStream);
+      
+      setIsMuted(false);
+      setIsVideoOff(false);
+      return mediaStream;
+    } catch (e) {
+      const err = e as DOMException;
+      console.warn('Failed to acquire media stream:', err.name);
+      if (err.name === 'NotAllowedError') {
+        setMediaError('Camera/mic blocked. Click the 🔒 icon in your browser\'s address bar to allow access, then try again.');
+      } else {
+        setMediaError(`Media error: ${err.name}`);
+      }
+      // Auto-dismiss after 6 seconds
+      setTimeout(() => setMediaError(null), 6000);
+      return null;
+    }
+  }
+  
+  async function handleToggleMic() {
     const user = localUser();
-    if (!user?.stream) return;
+    if (!user) return;
+    
+    if (!user.stream) {
+      await acquireStream();
+      return;
+    }
     
     const audioTrack = user.stream.getAudioTracks()[0];
     if (audioTrack) {
@@ -51,9 +97,14 @@ export const ControlBar: Component = () => {
     }
   }
   
-  function handleToggleCamera() {
+  async function handleToggleCamera() {
     const user = localUser();
-    if (!user?.stream) return;
+    if (!user) return;
+    
+    if (!user.stream) {
+      await acquireStream();
+      return;
+    }
     
     const videoTrack = user.stream.getVideoTracks()[0];
     if (videoTrack) {
@@ -149,115 +200,126 @@ export const ControlBar: Component = () => {
   const btnBase = 'flex items-center justify-center w-[52px] h-[52px] bg-surface border border-border rounded-xl text-text-primary cursor-pointer transition-all duration-(--transition-fast) hover:bg-surface-hover hover:-translate-y-0.5 max-[480px]:w-11 max-[480px]:h-11';
   
   return (
-    <div id="control-bar" class="fixed bottom-6 left-1/2 -translate-x-1/2 flex items-center gap-2 p-3 bg-bg-elevated border border-border rounded-2xl backdrop-blur-[12px] shadow-xl z-[100] max-[480px]:bottom-4 max-[480px]:gap-1 max-[480px]:p-2">
-      <button
-        id="btn-mic"
-        class={btnBase}
-        classList={{ 'bg-danger/20 border-danger text-danger': isMuted(), 'muted': isMuted() }}
-        title="Toggle Microphone"
-        onClick={handleToggleMic}
-      >
-        <Show when={!isMuted()}>
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
-            <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-            <line x1="12" y1="19" x2="12" y2="23" />
-            <line x1="8" y1="23" x2="16" y2="23" />
-          </svg>
-        </Show>
-        <Show when={isMuted()}>
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <line x1="1" y1="1" x2="23" y2="23" />
-            <path d="M9 9v3a3 3 0 0 0 5.12 2.12M15 9.34V4a3 3 0 0 0-5.94-.6" />
-            <path d="M17 16.95A7 7 0 0 1 5 12v-2m14 0v2c0 .74-.11 1.46-.32 2.14" />
-            <line x1="12" y1="19" x2="12" y2="23" />
-            <line x1="8" y1="23" x2="16" y2="23" />
-          </svg>
-        </Show>
-      </button>
-      
-      <button
-        id="btn-camera"
-        class={btnBase}
-        classList={{ 'bg-danger/20 border-danger text-danger': isVideoOff() }}
-        title="Toggle Camera"
-        onClick={handleToggleCamera}
-      >
-        <Show when={!isVideoOff()}>
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M23 7l-7 5 7 5V7z" />
-            <rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
-          </svg>
-        </Show>
-        <Show when={isVideoOff()}>
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M16 16v1a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2m5.66 0H14a2 2 0 0 1 2 2v3.34l1 1L23 7v10" />
-            <line x1="1" y1="1" x2="23" y2="23" />
-          </svg>
-        </Show>
-      </button>
-      
-      <button
-        id="btn-screen"
-        class={btnBase}
-        title="Share Screen"
-        onClick={handleStartScreenShare}
-      >
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
-          <line x1="8" y1="21" x2="16" y2="21" />
-          <line x1="12" y1="17" x2="12" y2="21" />
-        </svg>
-      </button>
-      
-      <button
-        id="btn-note"
-        class={btnBase}
-        title="Add Note"
-        onClick={handleCreateNote}
-      >
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M12 20h9" />
-          <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
-        </svg>
-      </button>
-      
-      {/* Divider */}
-      <div class="w-px h-8 bg-border mx-2" />
-      
-      <div id="activity-wrapper" class="relative">
-        <button 
-          id="btn-activity" 
+    <>
+      {/* Media permission error toast */}
+      <Show when={mediaError()}>
+        <div
+          class="fixed bottom-24 left-1/2 -translate-x-1/2 max-w-sm px-4 py-3 bg-danger/90 text-white text-sm rounded-xl shadow-lg z-[101] cursor-pointer backdrop-blur-sm animate-[fadeIn_0.2s_ease-out]"
+          onClick={() => setMediaError(null)}
+        >
+          {mediaError()}
+        </div>
+      </Show>
+      <div id="control-bar" class="fixed bottom-6 left-1/2 -translate-x-1/2 flex items-center gap-2 p-3 bg-bg-elevated border border-border rounded-2xl backdrop-blur-[12px] shadow-xl z-[100] max-[480px]:bottom-4 max-[480px]:gap-1 max-[480px]:p-2">
+        <button
+          id="btn-mic"
           class={btnBase}
-          classList={{ 'bg-accent border-accent shadow-[0_0_20px_var(--color-accent-glow)]': activityOpen() }}
-          title="Recent Activity"
-          onClick={handleToggleActivity}
+          classList={{ 'bg-danger/20 border-danger text-danger': isMuted(), 'muted': isMuted() }}
+          title="Toggle Microphone"
+          onClick={handleToggleMic}
+        >
+          <Show when={!isMuted()}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+              <line x1="12" y1="19" x2="12" y2="23" />
+              <line x1="8" y1="23" x2="16" y2="23" />
+            </svg>
+          </Show>
+          <Show when={isMuted()}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="1" y1="1" x2="23" y2="23" />
+              <path d="M9 9v3a3 3 0 0 0 5.12 2.12M15 9.34V4a3 3 0 0 0-5.94-.6" />
+              <path d="M17 16.95A7 7 0 0 1 5 12v-2m14 0v2c0 .74-.11 1.46-.32 2.14" />
+              <line x1="12" y1="19" x2="12" y2="23" />
+              <line x1="8" y1="23" x2="16" y2="23" />
+            </svg>
+          </Show>
+        </button>
+        
+        <button
+          id="btn-camera"
+          class={btnBase}
+          classList={{ 'bg-danger/20 border-danger text-danger': isVideoOff() }}
+          title="Toggle Camera"
+          onClick={handleToggleCamera}
+        >
+          <Show when={!isVideoOff()}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M23 7l-7 5 7 5V7z" />
+              <rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
+            </svg>
+          </Show>
+          <Show when={isVideoOff()}>
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M16 16v1a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2m5.66 0H14a2 2 0 0 1 2 2v3.34l1 1L23 7v10" />
+              <line x1="1" y1="1" x2="23" y2="23" />
+            </svg>
+          </Show>
+        </button>
+        
+        <button
+          id="btn-screen"
+          class={btnBase}
+          title="Share Screen"
+          onClick={handleStartScreenShare}
         >
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="10" />
-            <polyline points="12 6 12 12 16 14" />
+            <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+            <line x1="8" y1="21" x2="16" y2="21" />
+            <line x1="12" y1="17" x2="12" y2="21" />
           </svg>
-          {/* Activity badge - unread indicator */}
-          <span id="activity-badge" class="absolute top-2 right-2 w-2 h-2 bg-danger rounded-full shadow-[0_0_8px_var(--color-danger)] animate-pulse-badge" classList={{ 'hidden': !hasUnread() }} />
         </button>
-        <ActivityPanel isOpen={activityOpen()} onClose={() => setActivityOpen(false)} />
+        
+        <button
+          id="btn-note"
+          class={btnBase}
+          title="Add Note"
+          onClick={handleCreateNote}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M12 20h9" />
+            <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+          </svg>
+        </button>
+        
+        {/* Divider */}
+        <div class="w-px h-8 bg-border mx-2" />
+        
+        <div id="activity-wrapper" class="relative">
+          <button 
+            id="btn-activity" 
+            class={btnBase}
+            classList={{ 'bg-accent border-accent shadow-[0_0_20px_var(--color-accent-glow)]': activityOpen() }}
+            title="Recent Activity"
+            onClick={handleToggleActivity}
+          >
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="12" cy="12" r="10" />
+              <polyline points="12 6 12 12 16 14" />
+            </svg>
+            {/* Activity badge - unread indicator */}
+            <span id="activity-badge" class="absolute top-2 right-2 w-2 h-2 bg-danger rounded-full shadow-[0_0_8px_var(--color-danger)] animate-pulse-badge" classList={{ 'hidden': !hasUnread() }} />
+          </button>
+          <ActivityPanel isOpen={activityOpen()} onClose={() => setActivityOpen(false)} />
+        </div>
+        
+        {/* Divider */}
+        <div class="w-px h-8 bg-border mx-2" />
+        
+        <button
+          id="btn-leave"
+          class={`${btnBase} bg-danger/20 border-danger text-danger hover:bg-danger/30`}
+          title="Leave Space"
+          onClick={handleLeave}
+        >
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+            <polyline points="16 17 21 12 16 7" />
+            <line x1="21" y1="12" x2="9" y2="12" />
+          </svg>
+        </button>
       </div>
-      
-      {/* Divider */}
-      <div class="w-px h-8 bg-border mx-2" />
-      
-      <button
-        id="btn-leave"
-        class={`${btnBase} bg-danger/20 border-danger text-danger hover:bg-danger/30`}
-        title="Leave Space"
-        onClick={handleLeave}
-      >
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
-          <polyline points="16 17 21 12 16 7" />
-          <line x1="21" y1="12" x2="9" y2="12" />
-        </svg>
-      </button>
-    </div>
+    </>
   );
 };

--- a/client/components/JoinModal.tsx
+++ b/client/components/JoinModal.tsx
@@ -68,7 +68,7 @@ export const JoinModal: Component = () => {
     localStorage.setItem(STORAGE_KEY_USERNAME, name);
     
     try {
-      // Get media stream
+      // Get media stream (optional — user can join without camera/mic)
       let mediaStream = stream();
       if (!mediaStream) {
         try {
@@ -78,13 +78,8 @@ export const JoinModal: Component = () => {
           });
           setStream(mediaStream);
         } catch (mediaErr) {
-          const err = mediaErr as DOMException;
-          if (err.name === 'NotAllowedError') {
-            setError('Camera/microphone access denied. Please grant permission and try again.');
-          } else {
-            setError(`Media error: ${err.name}`);
-          }
-          return;
+          console.warn('Media access denied, joining without camera/mic:', (mediaErr as DOMException).name);
+          mediaStream = null;
         }
       }
       
@@ -103,8 +98,9 @@ export const JoinModal: Component = () => {
           const spawnY = myPeerData?.position?.y ?? 2000;
           
           // Connect CRDT and add ourselves with server-assigned position
+          const noMedia = !mediaStream;
           ctx.connectCRDT(space);
-          ctx.addPeer(peerId, name, spawnX, spawnY);
+          ctx.addPeer(peerId, name, spawnX, spawnY, noMedia, noMedia);
           
           // Set session state with server-assigned position
           ctx.setSession({
@@ -114,8 +110,8 @@ export const JoinModal: Component = () => {
               username: name,
               x: spawnX,
               y: spawnY,
-              isMuted: false,
-              isVideoOff: false,
+              isMuted: noMedia,
+              isVideoOff: noMedia,
               status: '',
               stream: mediaStream,
             },

--- a/client/context/SpaceContext.tsx
+++ b/client/context/SpaceContext.tsx
@@ -71,7 +71,7 @@ interface SpaceContextValue {
   emitSocket: (event: string, data: unknown) => void;
   
   // CRDT mutation helpers
-  addPeer: (peerId: string, username: string, x: number, y: number) => void;
+  addPeer: (peerId: string, username: string, x: number, y: number, isMuted?: boolean, isVideoOff?: boolean) => void;
   removePeer: (peerId: string) => void;
   updatePeerPosition: (peerId: string, x: number, y: number) => void;
   updatePeerMediaState: (peerId: string, isMuted: boolean, isVideoOff: boolean) => void;
@@ -88,6 +88,7 @@ interface SpaceContextValue {
   setScreenShareStream: (shareId: string, stream: MediaStream) => void;
   removeScreenShareStream: (shareId: string) => void;
   addScreenShareToPeers: (stream: MediaStream) => Promise<void>;
+  addLocalStreamToPeers: (stream: MediaStream) => Promise<void>;
   
   // Remote peer streams (for Avatar video)
   peerStreams: Accessor<Map<string, MediaStream>>;
@@ -442,8 +443,8 @@ export const SpaceProvider: ParentComponent = (props) => {
   }
   
   // CRDT Mutations
-  function addPeer(peerId: string, username: string, x: number, y: number) {
-    peersMap?.set(peerId, { username, x, y, isMuted: false, isVideoOff: false, status: '' });
+  function addPeer(peerId: string, username: string, x: number, y: number, isMuted = false, isVideoOff = false) {
+    peersMap?.set(peerId, { username, x, y, isMuted, isVideoOff, status: '' });
   }
   
   function removePeer(peerId: string) {
@@ -598,6 +599,39 @@ export const SpaceProvider: ParentComponent = (props) => {
       });
       
       // Trigger renegotiation by creating a new offer
+      try {
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+        emitSocket('signal', {
+          to: peerId,
+          from: session()?.localUser.peerId,
+          signal: { type: 'offer', sdp: offer },
+        });
+      } catch (e) {
+        console.error(`[WebRTC] Failed to renegotiate with ${peerId}:`, e);
+      }
+    }
+  }
+  
+  /**
+   * Add local webcam tracks to all existing peer connections.
+   * Used when a user enables their camera/mic after joining without media.
+   */
+  async function addLocalStreamToPeers(stream: MediaStream) {
+    console.log(`[WebRTC] Adding local stream to ${peerConnections.size} peer connections`);
+    
+    for (const [peerId, pc] of peerConnections.entries()) {
+      const senders = pc.getSenders();
+      const existingTrackIds = new Set(senders.map(s => s.track?.id).filter(Boolean));
+      
+      stream.getTracks().forEach(track => {
+        if (!existingTrackIds.has(track.id)) {
+          console.log(`[WebRTC] Adding local track to ${peerId}: ${track.kind}`);
+          pc.addTrack(track, stream);
+        }
+      });
+      
+      // Trigger renegotiation
       try {
         const offer = await pc.createOffer();
         await pc.setLocalDescription(offer);
@@ -861,6 +895,7 @@ export const SpaceProvider: ParentComponent = (props) => {
     setScreenShareStream,
     removeScreenShareStream,
     addScreenShareToPeers,
+    addLocalStreamToPeers,
     peerStreams,
     setPeerStream,
     removePeerStream,

--- a/e2e/dsl/index.ts
+++ b/e2e/dsl/index.ts
@@ -27,6 +27,7 @@ async function joinSpace(page: Page, username: string, spaceId: string): Promise
 
 class UserBuilderImpl implements UserBuilder {
   private webcamColor: string | null = null;
+  private denyMedia = false;
   
   constructor(
     private name: string,
@@ -40,10 +41,25 @@ class UserBuilderImpl implements UserBuilder {
     return this;
   }
 
+  withoutWebcam(): UserBuilder {
+    this.denyMedia = true;
+    return this;
+  }
+
   async join(): Promise<User> {
     const context = await this.contextFactory();
     this.contexts.push(context);
     const page = await context.newPage();
+    
+    // When denyMedia is set, override getUserMedia to throw NotAllowedError
+    // (headless Chromium auto-grants permissions, so we must mock it)
+    if (this.denyMedia) {
+      await page.addInitScript(() => {
+        navigator.mediaDevices.getUserMedia = async () => {
+          throw new DOMException('Permission denied', 'NotAllowedError');
+        };
+      });
+    }
     
     // Navigate to space first to load the SPA (so navigator.mediaDevices exists)
     await page.goto(`/s/${this.spaceId}`);

--- a/e2e/dsl/types.ts
+++ b/e2e/dsl/types.ts
@@ -56,6 +56,8 @@ export interface UserBuilder {
   join(): Promise<User>;
   /** Mock the webcam with an animated canvas stream before joining */
   withMockedWebcam(color?: string): UserBuilder;
+  /** Join without granting camera/microphone permissions */
+  withoutWebcam(): UserBuilder;
 }
 
 export interface User {
@@ -80,6 +82,9 @@ export interface User {
   touchDragAvatar(delta: { dx: number; dy: number }): Promise<void>;
   goOffline(): Promise<void>;
   goOnline(): Promise<void>;
+
+  /** Restore getUserMedia (after withoutWebcam) so camera can be re-enabled */
+  enableWebcam(color?: string): Promise<void>;
   
   // Text Note Actions
   createTextNote(): Promise<TextNoteInfo>;

--- a/e2e/dsl/user.ts
+++ b/e2e/dsl/user.ts
@@ -17,7 +17,7 @@ import {
   ActivityItem,
 } from './types';
 import { AvatarViewImpl, ScreenShareViewImpl, TextNoteViewImpl } from './views';
-import { mockScreenShare } from './mocks';
+import { mockScreenShare, mockWebcam } from './mocks';
 
 const SYNC_TIMEOUT = 10000;
 
@@ -225,6 +225,10 @@ export class UserImpl implements User {
     await this.page.evaluate(() => {
       window.dispatchEvent(new Event('online'));
     });
+  }
+
+  async enableWebcam(color: string = 'green'): Promise<void> {
+    await mockWebcam(this.page, color);
   }
 
   // ─────────────────────────────────────────────────────────────────

--- a/e2e/scenarios/no-media.spec.ts
+++ b/e2e/scenarios/no-media.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * No-Media Scenarios
+ * 
+ * Tests for joining a space without granting camera/microphone permissions.
+ */
+import { expect } from '@playwright/test';
+import { scenario } from '../dsl';
+
+scenario('user joins without media', 'no-media-join', async ({ createUser }) => {
+  const alice = await createUser('Alice').withoutWebcam().join();
+  const bob = await createUser('Bob').withMockedWebcam('blue').join();
+  
+  await bob.waitForUser('Alice');
+  
+  // Alice's webcam should appear off (showing initial letter, not video)
+  await expect.poll(async () =>
+    await bob.avatarOf('Alice').isWebcamOn()
+  , { timeout: 5000 }).toBe(false);
+  
+  // Alice can see Bob
+  expect(await alice.visibleUsers()).toEqual(['Bob']);
+});
+
+scenario('no-media user can interact with space', 'no-media-interact', async ({ createUser }) => {
+  const alice = await createUser('Alice').withoutWebcam().join();
+  
+  // Alice can create a text note despite having no media
+  const note = await alice.createTextNote();
+  expect(note).toBeTruthy();
+  
+  // Alice can edit the note
+  await alice.editTextNote('Hello from no-cam Alice');
+  await expect.poll(async () => {
+    const content = await alice.textNoteOf('any').content();
+    return content;
+  }, { timeout: 5000 }).toContain('Hello from no-cam Alice');
+});
+
+scenario('no-media user can re-enable camera', 'no-media-reenable', async ({ createUser }) => {
+  const alice = await createUser('Alice').withoutWebcam().join();
+  const bob = await createUser('Bob').withMockedWebcam('blue').join();
+  await bob.waitForUser('Alice');
+  
+  // Alice's webcam starts off
+  await expect.poll(async () =>
+    await bob.avatarOf('Alice').isWebcamOn()
+  , { timeout: 5000 }).toBe(false);
+  
+  // Alice restores getUserMedia (simulates granting permission) and clicks camera button
+  await alice.enableWebcam('red');
+  await alice.toggleWebcam();
+  
+  // Bob should now see Alice's webcam as ON
+  await expect.poll(async () =>
+    await bob.avatarOf('Alice').isWebcamOn()
+  , { timeout: 10000 }).toBe(true);
+});


### PR DESCRIPTION
Allow users to join a space even when they decline the browser's camera/microphone permission prompt. Previously, declining blocked the user entirely.

## Changes

- **JoinModal**: Catch `getUserMedia` errors and proceed with `stream: null` instead of blocking
- **SpaceContext**: `addPeer` accepts optional `isMuted`/`isVideoOff` params; new `addLocalStreamToPeers` method for late-joining media tracks
- **ControlBar**: Initialize button state from session; `acquireStream()` re-attempts `getUserMedia` when clicking camera/mic with no stream; error toast when permissions are still blocked
- **E2E**: `withoutWebcam()` builder, `enableWebcam()` user action, 3 new test scenarios

## User Flow

1. User declines camera/mic prompt → joins with video off and muted
2. User clicks camera/mic button → `acquireStream()` calls `getUserMedia` again
   - If granted: stream is acquired, session updated, tracks sent to peers
   - If still blocked: red toast with instructions to reset permissions via 🔒 icon
