### PR TITLE
Fix WebRTC TURN relay: fetch ICE servers from API

### DIFF
--- a/client/components/JoinModal.tsx
+++ b/client/components/JoinModal.tsx
@@ -91,7 +91,7 @@ export const JoinModal: Component = () => {
         const peerId = connData.peerId;
         
         // Wait for space-state which contains our server-assigned position
-        ctx.onceSocket<SpaceStateEvent>('space-state', (stateData) => {
+        ctx.onceSocket<SpaceStateEvent>('space-state', async (stateData) => {
           // Get our server-assigned position from space-state
           const myPeerData = stateData.peers[peerId];
           const spawnX = myPeerData?.position?.x ?? 2000;
@@ -116,6 +116,9 @@ export const JoinModal: Component = () => {
               stream: mediaStream,
             },
           });
+          
+          // Fetch ICE servers (includes TURN credentials) before WebRTC setup
+          await ctx.fetchIceServers();
           
           // Initialize WebRTC for peer connections
           ctx.initWebRTC();

--- a/client/context/SpaceContext.tsx
+++ b/client/context/SpaceContext.tsx
@@ -96,6 +96,7 @@ interface SpaceContextValue {
   removePeerStream: (peerId: string) => void;
   
   // WebRTC
+  fetchIceServers: () => Promise<void>;
   initWebRTC: () => void;
   
   // Text note mutations
@@ -128,6 +129,13 @@ export const SpaceProvider: ParentComponent = (props) => {
   // Local media streams (not in CRDT, but needed for rendering)
   const [screenShareStreams, setScreenShareStreams] = createSignal<Map<string, MediaStream>>(new Map());
   const [peerStreams, setPeerStreams] = createSignal<Map<string, MediaStream>>(new Map());
+  
+  // ICE server config (fetched from server, includes TURN credentials when configured)
+  const FALLBACK_ICE_SERVERS: RTCIceServer[] = [
+    { urls: 'stun:stun.l.google.com:19302' },
+    { urls: 'stun:stun1.l.google.com:19302' },
+  ];
+  let iceServers: RTCIceServer[] = FALLBACK_ICE_SERVERS;
   
   // Derived values
   const participantCount = createMemo(() => peers().size);
@@ -750,13 +758,24 @@ export const SpaceProvider: ParentComponent = (props) => {
     });
   }
   
+  /**
+   * Fetch ICE servers (including TURN credentials) from the server API.
+   * Must be called before initWebRTC() to ensure TURN relay is available.
+   */
+  async function fetchIceServers(): Promise<void> {
+    try {
+      const response = await fetch('/api/ice-servers');
+      if (response.ok) {
+        iceServers = await response.json();
+        console.log('[WebRTC] ICE servers loaded:', iceServers.length, 'servers');
+      }
+    } catch (error) {
+      console.warn('[WebRTC] Failed to fetch ICE servers, using STUN-only fallback:', error);
+    }
+  }
+  
   function createPeerConnection(peerId: string): RTCPeerConnection {
-    const pc = new RTCPeerConnection({
-      iceServers: [
-        { urls: 'stun:stun.l.google.com:19302' },
-        { urls: 'stun:stun1.l.google.com:19302' },
-      ],
-    });
+    const pc = new RTCPeerConnection({ iceServers });
     peerConnections.set(peerId, pc);
     
     pc.onicecandidate = (event) => {
@@ -898,6 +917,7 @@ export const SpaceProvider: ParentComponent = (props) => {
     addLocalStreamToPeers,
     peerStreams,
     setPeerStream,
+    fetchIceServers,
     removePeerStream,
     initWebRTC,
   };

--- a/e2e/scenarios/ice-servers.spec.ts
+++ b/e2e/scenarios/ice-servers.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * ICE Server Configuration Regression Test
+ *
+ * Verifies the client fetches ICE servers from the server API and uses
+ * them for WebRTC peer connections. Catches regressions like the SolidJS
+ * migration (f731315) that hardcoded STUN-only and dropped TURN support.
+ */
+import { test, expect } from '@playwright/test';
+
+test('client fetches ICE servers from /api/ice-servers before creating peer connections', async ({ browser }) => {
+  // Track whether the client fetches the ICE servers endpoint
+  let iceServersFetched = false;
+
+  const context = await browser.newContext({
+    permissions: ['camera', 'microphone'],
+    ignoreHTTPSErrors: true,
+  });
+
+  const page = await context.newPage();
+
+  // Intercept /api/ice-servers requests to track that the client calls it
+  await page.route('**/api/ice-servers', async (route) => {
+    iceServersFetched = true;
+    // Let the request continue to the real server
+    await route.continue();
+  });
+
+  // Join a space
+  await page.goto('/s/ice-test');
+  await page.locator('#join-form').waitFor({ state: 'visible', timeout: 10000 });
+  await page.fill('#username', 'IceTester');
+  await page.locator('#join-form').evaluate((form: HTMLFormElement) => form.requestSubmit());
+  await expect(page.locator('#control-bar')).toBeVisible({ timeout: 10000 });
+
+  // The client should have fetched ICE servers before establishing WebRTC
+  expect(iceServersFetched).toBe(true);
+
+  await context.close();
+});
+
+test('GET /api/ice-servers returns valid ICE server config', async ({ browser }) => {
+  const context = await browser.newContext({ ignoreHTTPSErrors: true });
+  const page = await context.newPage();
+
+  // Navigate into the SPA so we have a valid origin
+  await page.goto('/s/ice-api-test');
+  await page.locator('#join-form').waitFor({ state: 'visible', timeout: 10000 });
+
+  // Use Playwright's request API (respects context's TLS settings)
+  const response = await context.request.get('/api/ice-servers');
+  expect(response.ok()).toBe(true);
+
+  const servers = await response.json();
+  expect(Array.isArray(servers)).toBe(true);
+  expect(servers.length).toBeGreaterThan(0);
+
+  // Each entry should have a `urls` field
+  for (const server of servers) {
+    expect(server).toHaveProperty('urls');
+  }
+
+  await context.close();
+});

--- a/server/main.ts
+++ b/server/main.ts
@@ -90,12 +90,15 @@ const protocol = config.https ? 'https' : 'http';
         appType: 'spa',
       });
 
-      // Vite middleware first (HMR, module transforms, SPA fallback),
-      // then Hono for API routes that Vite doesn't handle
+      // API routes go to Hono first; everything else goes through Vite (HMR, module transforms, SPA fallback)
       server.on('request', (req: IncomingMessage, res: ServerResponse) => {
-        vite.middlewares(req, res, () => {
+        if (req.url?.startsWith('/api/')) {
           honoListener(req, res);
-        });
+        } else {
+          vite.middlewares(req, res, () => {
+            honoListener(req, res);
+          });
+        }
       });
 
       console.log(`🔥 Vite HMR enabled (dev mode)`);


### PR DESCRIPTION
## Problem

Users behind restrictive NATs (e.g. in India) cannot establish WebRTC connections — camera/mic don't work, they can't see or hear others. Console shows `[WebRTC] Connection with ... failed`.

Fixes #79.

## Root Cause

The SolidJS migration (`f731315`) rewrote all WebRTC code and dropped the `fetchIceServers()` call that previously fetched TURN credentials from `/api/ice-servers`. The client was hardcoding STUN-only servers, so users who need TURN relay could never connect.

Additionally, Vite's SPA middleware in dev mode was silently intercepting `/api/*` routes before Hono could handle them, returning HTML instead of JSON.

## Changes

| File | Change |
|------|--------|
| `client/context/SpaceContext.tsx` | Added `fetchIceServers()` that calls `GET /api/ice-servers` with STUN-only fallback; `createPeerConnection()` uses cached config |
| `client/components/JoinModal.tsx` | Calls `fetchIceServers()` before `initWebRTC()` in the join flow |
| `server/main.ts` | Routes `/api/*` to Hono before Vite SPA middleware in dev mode |
| `e2e/scenarios/ice-servers.spec.ts` | **[NEW]** Two E2E tests: verifies client fetches ICE servers + validates API response |

## Testing

- `just e2e-quick "ice-servers"` → 2 passed
- `just e2e-quick "connection"` → 5 passed
- `just e2e-quick` → 78/83 passed (5 pre-existing flaky failures unrelated)
