### PR TITLE
Extract createDraggable hook from Avatar.tsx

### DIFF
--- a/client/components/Canvas/Avatar.tsx
+++ b/client/components/Canvas/Avatar.tsx
@@ -2,10 +2,11 @@
  * Avatar Component
  * Represents a peer in the space with video, username, and status.
  */
-import { Component, createMemo, Show, createSignal, onMount, onCleanup, createEffect } from 'solid-js';
+import { Component, createMemo, Show, createSignal, createEffect } from 'solid-js';
 import { useSpace } from '@/context/SpaceContext';
 import { t } from '@/lib/i18n';
 import { avatarGradient, avatarHue } from '@/lib/avatarColor';
+import { useDraggable } from '@/hooks/useDraggable';
 
 interface AvatarProps {
   peerId: string;
@@ -18,7 +19,6 @@ export const Avatar: Component<AvatarProps> = (props) => {
   let avatarRef: HTMLDivElement | undefined;
   let videoRef: HTMLVideoElement | undefined;
   
-  const [isDragging, setIsDragging] = createSignal(false);
   const [showStatusPopover, setShowStatusPopover] = createSignal(false);
   const [statusInput, setStatusInput] = createSignal('');
   let statusInputRef: HTMLInputElement | undefined;
@@ -41,108 +41,19 @@ export const Avatar: Component<AvatarProps> = (props) => {
     }
   });
   
+  // Drag behavior for local avatar
+  const draggable = useDraggable({
+    position: () => ({ x: peer()?.x ?? 0, y: peer()?.y ?? 0 }),
+    onMove: (x, y) => ctx.updatePeerPosition(props.peerId, x, y),
+    onDragEnd: (pos) => ctx.emitSocket('position-update', pos),
+    skipButtonCheck: true,
+  });
+  
   // Callback ref to setup drag when element is ready
   const setAvatarRef = (el: HTMLDivElement) => {
     avatarRef = el;
-    if (props.isLocal && avatarRef) {
-      setupDrag();
-    }
+    if (props.isLocal) draggable.setup(el);
   };
-  
-  function setupDrag() {
-    if (!avatarRef || !props.isLocal) return;
-    
-    let startDragX = 0;
-    let startDragY = 0;
-    let initialX = 0;
-    let initialY = 0;
-    
-    const handleMouseDown = (e: MouseEvent) => {
-      e.stopPropagation();
-      setIsDragging(true);
-      startDragX = e.clientX;
-      startDragY = e.clientY;
-      initialX = peer()?.x ?? 0;
-      initialY = peer()?.y ?? 0;
-      avatarRef!.style.cursor = 'grabbing';
-    };
-    
-    const handleMouseMove = (e: MouseEvent) => {
-      if (!isDragging()) return;
-      e.preventDefault(); // Prevent scrolling while dragging
-      
-      const deltaX = e.clientX - startDragX;
-      const deltaY = e.clientY - startDragY;
-      
-      const newX = initialX + deltaX;
-      const newY = initialY + deltaY;
-      
-      ctx.updatePeerPosition(props.peerId, newX, newY);
-    };
-    
-    const handleMouseUp = () => {
-      if (isDragging()) {
-        setIsDragging(false);
-        if (avatarRef) {
-          avatarRef.style.cursor = 'grab';
-        }
-        // Notify server of final position so spawn placement uses live data
-        const p = peer();
-        if (p) ctx.emitSocket('position-update', { x: p.x, y: p.y });
-      }
-    };
-    
-    avatarRef.addEventListener('mousedown', handleMouseDown);
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-    
-    // Touch events
-    const handleTouchStart = (e: TouchEvent) => {
-      if (e.touches.length !== 1) return;
-      e.stopPropagation();
-      e.preventDefault(); // Prevent browser scroll — requires { passive: false }
-      setIsDragging(true);
-      startDragX = e.touches[0].clientX;
-      startDragY = e.touches[0].clientY;
-      initialX = peer()?.x ?? 0;
-      initialY = peer()?.y ?? 0;
-    };
-    
-    const handleTouchMove = (e: TouchEvent) => {
-      if (!isDragging() || e.touches.length !== 1) return;
-      e.preventDefault(); // Prevent scrolling while dragging
-      
-      const deltaX = e.touches[0].clientX - startDragX;
-      const deltaY = e.touches[0].clientY - startDragY;
-      
-      const newX = initialX + deltaX;
-      const newY = initialY + deltaY;
-      
-      ctx.updatePeerPosition(props.peerId, newX, newY);
-    };
-    
-    const handleTouchEnd = () => {
-      if (isDragging()) {
-        setIsDragging(false);
-        // Notify server of final position so spawn placement uses live data
-        const p = peer();
-        if (p) ctx.emitSocket('position-update', { x: p.x, y: p.y });
-      }
-    };
-    
-    avatarRef.addEventListener('touchstart', handleTouchStart, { passive: false });
-    document.addEventListener('touchmove', handleTouchMove, { passive: false });
-    document.addEventListener('touchend', handleTouchEnd);
-    
-    onCleanup(() => {
-      avatarRef?.removeEventListener('mousedown', handleMouseDown);
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-      avatarRef?.removeEventListener('touchstart', handleTouchStart);
-      document.removeEventListener('touchmove', handleTouchMove);
-      document.removeEventListener('touchend', handleTouchEnd);
-    });
-  }
   
   return (
     <Show when={peer()}>

--- a/client/hooks/useDraggable.ts
+++ b/client/hooks/useDraggable.ts
@@ -1,6 +1,7 @@
 /**
  * useDraggable Hook
  * Provides consistent drag behavior for draggable elements via a header/handle.
+ * Supports both mouse and touch input with optional drag-end notification.
  * Uses refs for drag state to avoid reactive updates during drag.
  */
 import { createSignal, onCleanup, Accessor } from 'solid-js';
@@ -10,13 +11,17 @@ export interface DragConfig {
   position: Accessor<{ x: number; y: number }>;
   /** Callback when element is dragged to a new position */
   onMove: (x: number, y: number) => void;
+  /** Optional callback when drag ends with the final position */
+  onDragEnd?: (pos: { x: number; y: number }) => void;
+  /** If true, allow dragging even when clicking on buttons (default: false) */
+  skipButtonCheck?: boolean;
 }
 
 export interface DragResult {
   /** Signal indicating if currently dragging */
   isDragging: Accessor<boolean>;
-  /** Setup function to call in onMount with header/handle ref */
-  setup: (headerRef: HTMLElement) => void;
+  /** Setup function to call with the drag handle element */
+  setup: (handleRef: HTMLElement) => void;
 }
 
 export function useDraggable(config: DragConfig): DragResult {
@@ -30,48 +35,82 @@ export function useDraggable(config: DragConfig): DragResult {
     initialY: 0,
   };
 
-  function setup(headerRef: HTMLElement) {
-    const handleMouseDown = (e: MouseEvent) => {
-      // Don't drag if clicking on a button
-      if ((e.target as HTMLElement).closest('button')) return;
+  function startDrag(clientX: number, clientY: number) {
+    const pos = config.position();
+    dragState.isDragging = true;
+    dragState.startX = clientX;
+    dragState.startY = clientY;
+    dragState.initialX = pos.x;
+    dragState.initialY = pos.y;
+    setIsDragging(true);
+  }
 
+  function moveDrag(clientX: number, clientY: number) {
+    if (!dragState.isDragging) return;
+    const deltaX = clientX - dragState.startX;
+    const deltaY = clientY - dragState.startY;
+    config.onMove(dragState.initialX + deltaX, dragState.initialY + deltaY);
+  }
+
+  function endDrag() {
+    if (!dragState.isDragging) return;
+    dragState.isDragging = false;
+    setIsDragging(false);
+    if (config.onDragEnd) {
+      const pos = config.position();
+      config.onDragEnd({ x: pos.x, y: pos.y });
+    }
+  }
+
+  function setup(handleRef: HTMLElement) {
+    // --- Mouse events ---
+    const handleMouseDown = (e: MouseEvent) => {
+      if (!config.skipButtonCheck && (e.target as HTMLElement).closest('button')) return;
       e.stopPropagation();
       e.preventDefault();
-
-      const pos = config.position();
-      dragState.isDragging = true;
-      dragState.startX = e.clientX;
-      dragState.startY = e.clientY;
-      dragState.initialX = pos.x;
-      dragState.initialY = pos.y;
-      setIsDragging(true);
+      startDrag(e.clientX, e.clientY);
     };
 
     const handleMouseMove = (e: MouseEvent) => {
       if (!dragState.isDragging) return;
       e.preventDefault();
-
-      const deltaX = e.clientX - dragState.startX;
-      const deltaY = e.clientY - dragState.startY;
-
-      config.onMove(dragState.initialX + deltaX, dragState.initialY + deltaY);
+      moveDrag(e.clientX, e.clientY);
     };
 
-    const handleMouseUp = () => {
-      if (dragState.isDragging) {
-        dragState.isDragging = false;
-        setIsDragging(false);
-      }
-    };
+    const handleMouseUp = () => endDrag();
 
-    headerRef.addEventListener('mousedown', handleMouseDown);
+    handleRef.addEventListener('mousedown', handleMouseDown);
     document.addEventListener('mousemove', handleMouseMove);
     document.addEventListener('mouseup', handleMouseUp);
 
+    // --- Touch events ---
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) return;
+      if (!config.skipButtonCheck && (e.target as HTMLElement).closest('button')) return;
+      e.stopPropagation();
+      e.preventDefault();
+      startDrag(e.touches[0].clientX, e.touches[0].clientY);
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (!dragState.isDragging || e.touches.length !== 1) return;
+      e.preventDefault();
+      moveDrag(e.touches[0].clientX, e.touches[0].clientY);
+    };
+
+    const handleTouchEnd = () => endDrag();
+
+    handleRef.addEventListener('touchstart', handleTouchStart, { passive: false });
+    document.addEventListener('touchmove', handleTouchMove, { passive: false });
+    document.addEventListener('touchend', handleTouchEnd);
+
     onCleanup(() => {
-      headerRef.removeEventListener('mousedown', handleMouseDown);
+      handleRef.removeEventListener('mousedown', handleMouseDown);
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
+      handleRef.removeEventListener('touchstart', handleTouchStart);
+      document.removeEventListener('touchmove', handleTouchMove);
+      document.removeEventListener('touchend', handleTouchEnd);
     });
   }
 


### PR DESCRIPTION
## Problem

Fixes #96

Avatar.tsx had ~90 lines of inline drag logic (mouse + touch handlers, position updates, socket emission) duplicating the pattern already in `useDraggable.ts`.

## Changes

| File | Change |
|------|--------|
| `client/hooks/useDraggable.ts` | Added touch event support (`touchstart`/`touchmove`/`touchend`), optional `onDragEnd` callback, and `skipButtonCheck` flag. Refactored internals into shared `startDrag`/`moveDrag`/`endDrag` helpers. |
| `client/components/Canvas/Avatar.tsx` | Replaced ~90 lines of inline drag logic with 5-line `useDraggable` call. Removed `isDragging` signal, `setupDrag()`, and unused imports. **271 → 181 lines**. |

**Bonus**: ScreenShare and TextNote gain touch dragging for free — no changes needed to those consumers.

## Testing

```
just e2e-quick
93 passed (1.2m)
```
