### PR TITLE
feat: Avatar Proximity Spatial Audio

### DIFF
--- a/client/components/Canvas/Avatar.tsx
+++ b/client/components/Canvas/Avatar.tsx
@@ -2,11 +2,12 @@
  * Avatar Component
  * Represents a peer in the space with video, username, and status.
  */
-import { Component, createMemo, Show, createSignal, createEffect } from 'solid-js';
+import { Component, createMemo, Show, createSignal, createEffect, onCleanup } from 'solid-js';
 import { useSpace } from '@/context/SpaceContext';
 import { t } from '@/lib/i18n';
 import { avatarGradient, avatarHue } from '@/lib/avatarColor';
 import { useDraggable } from '@/hooks/useDraggable';
+import { calculateSpatialVolume } from '@/lib/spatialAudio';
 
 interface AvatarProps {
   peerId: string;
@@ -22,6 +23,9 @@ export const Avatar: Component<AvatarProps> = (props) => {
   const [showStatusPopover, setShowStatusPopover] = createSignal(false);
   const [statusInput, setStatusInput] = createSignal('');
   let statusInputRef: HTMLInputElement | undefined;
+  
+  // Track computed volume for E2E tests (0-100)
+  const [currentVolume, setCurrentVolume] = createSignal(100);
   
   const peer = createMemo(() => ctx.peers().get(props.peerId));
   
@@ -39,6 +43,49 @@ export const Avatar: Component<AvatarProps> = (props) => {
     if (videoRef && s) {
       videoRef.srcObject = s;
     }
+  });
+
+  // Spatial Audio loop for remote peers
+  let audioLoopId: number;
+  createEffect(() => {
+    if (props.isLocal || !videoRef) return;
+    
+    const updateVolume = () => {
+      const p = peer();
+      const localUser = ctx.session()?.localUser;
+      
+      if (p && localUser) {
+        // Read live position from CRDT peers map for local user
+        const localPeerState = ctx.peers().get(localUser.peerId) || localUser;
+        
+        const dx = p.x - localPeerState.x;
+        const dy = p.y - localPeerState.y;
+        const distance = Math.sqrt(dx * dx + dy * dy);
+        
+        const volumeFactor = calculateSpatialVolume(distance);
+        
+        try {
+          if (Math.abs(videoRef.volume - volumeFactor) > 0.01) {
+            videoRef.volume = volumeFactor;
+            setCurrentVolume(Math.round(volumeFactor * 100));
+          }
+        } catch (e) {
+          // Ignore
+        }
+      }
+      
+      audioLoopId = requestAnimationFrame(updateVolume);
+    };
+    
+    updateVolume();
+    
+    // Cleanup is handled by solid-js createEffect cleanup convention or explicitly below
+  });
+  
+  
+  // Cleanup RAF
+  onCleanup(() => {
+    if (audioLoopId) cancelAnimationFrame(audioLoopId);
   });
   
   // Drag behavior for local avatar
@@ -71,6 +118,7 @@ export const Avatar: Component<AvatarProps> = (props) => {
           }}
           data-peer-id={props.peerId}
           data-avatar-hue={avatarHue(p().username)}
+          data-volume={currentVolume()}
         >
           {/* Video container */}
           <div class={`avatar-video-container relative w-full h-full rounded-full overflow-hidden bg-bg-tertiary shadow-lg transition-all duration-(--transition-fast) ${props.isLocal ? 'border-3 border-accent' : 'border-3 border-border'}`}>

--- a/client/components/Canvas/MediaPlayer.tsx
+++ b/client/components/Canvas/MediaPlayer.tsx
@@ -9,6 +9,7 @@ import { useDraggable } from '@/hooks/useDraggable';
 import { useResizable } from '@/hooks/useResizable';
 import { CloseButton } from './CloseButton';
 import { t } from '@/lib/i18n';
+import { calculateSpatialVolume } from '@/lib/spatialAudio';
 
 // Extend window object for YouTube API
 declare global {
@@ -222,17 +223,8 @@ export const MediaPlayer: Component<MediaPlayerProps> = (props) => {
         const distance = Math.sqrt(dx * dx + dy * dy);
         
         // Attenuate volume
-        // Similar to useLocalMedia webRTC
-        const MAX_HEARING_DISTANCE = 1500;
-        const MAX_VOLUME_DISTANCE = 300;
-        
-        let volume = 100;
-        if (distance > MAX_HEARING_DISTANCE) {
-          volume = 0;
-        } else if (distance > MAX_VOLUME_DISTANCE) {
-          const factor = 1 - ((distance - MAX_VOLUME_DISTANCE) / (MAX_HEARING_DISTANCE - MAX_VOLUME_DISTANCE));
-          volume = Math.floor(factor * factor * 100);
-        }
+        // Get volume factor (0.0 to 1.0) and convert to YouTube API format (0 to 100)
+        let volume = Math.floor(calculateSpatialVolume(distance) * 100);
         
         try {
           const currentVol = ytPlayer.getVolume();

--- a/client/lib/spatialAudio.ts
+++ b/client/lib/spatialAudio.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared utility for calculating spatial audio volume based on Euclidean distance
+ * between an audio source and a listener on the canvas.
+ * 
+ * Returns a volume factor between 0.0 and 1.0.
+ */
+export function calculateSpatialVolume(
+  distance: number,
+  maxVolumeDistance: number = 300,
+  maxHearingDistance: number = 1500
+): number {
+  if (distance > maxHearingDistance) {
+    return 0.0;
+  } else if (distance > maxVolumeDistance) {
+    const factor = 1.0 - ((distance - maxVolumeDistance) / (maxHearingDistance - maxVolumeDistance));
+    // Square the factor for a slightly more natural inverse-square-like dropoff
+    return factor * factor;
+  }
+  return 1.0;
+}

--- a/e2e/dsl/types.ts
+++ b/e2e/dsl/types.ts
@@ -149,6 +149,8 @@ export interface AvatarView {
   hasVideoContent(): Promise<boolean>;
   /** Get the avatar's unique hue (from data-avatar-hue attribute) */
   avatarColor(): Promise<string>;
+  /** Get the avatar's computed spatial audio volume (0-100) */
+  audioVolume(): Promise<number>;
 }
 
 export interface ScreenShareView {

--- a/e2e/dsl/views.ts
+++ b/e2e/dsl/views.ts
@@ -116,6 +116,11 @@ export class AvatarViewImpl implements AvatarView {
     const hue = await this.locator.getAttribute('data-avatar-hue');
     return hue ?? '';
   }
+
+  async audioVolume(): Promise<number> {
+    const volStr = await this.locator.getAttribute('data-volume');
+    return volStr ? parseInt(volStr, 10) : 100;
+  }
 }
 
 export class ScreenShareViewImpl implements ScreenShareView {

--- a/e2e/scenarios/spatial-audio.spec.ts
+++ b/e2e/scenarios/spatial-audio.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from '@playwright/test';
+import { scenario, SYNC_TIMEOUT } from '../dsl';
+
+scenario('avatar audio tracking attenuates over distance', 'test-spatial-audio', async ({ createUser }) => {
+  const alice = await createUser('Alice').join();
+  const bob = await createUser('Bob').join();
+
+  await alice.waitForUser('Bob');
+  await bob.waitForUser('Alice');
+
+  // Wait for initial sync, volumes should start at 100
+  await expect.poll(async () => {
+    return await bob.avatarOf('Alice').audioVolume();
+  }, { timeout: SYNC_TIMEOUT }).toBe(100);
+
+  // Bob moves slightly away (e.g. 400px) from Alice
+  // Max volume distance is 300, so 400 will cause a drop in volume but keep him onscreen
+  await bob.dragAvatar({ dx: 400, dy: 0 });
+  
+  // Alice handles syncing and her avatar calculates new distance
+  // Wait for Bob's client to parse the drop in Alice's volume
+  await expect.poll(async () => {
+    return await bob.avatarOf('Alice').audioVolume();
+  }, { timeout: SYNC_TIMEOUT }).toBeLessThan(100);
+  
+  const attenuatedVolume = await bob.avatarOf('Alice').audioVolume();
+  expect(attenuatedVolume).toBeGreaterThan(0); // Should not be 0 yet
+
+  // Bob moves back to origin
+  await bob.dragAvatar({ dx: -400, dy: 0 });
+
+  // Volume should recover back to 100
+  await expect.poll(async () => {
+    return await bob.avatarOf('Alice').audioVolume();
+  }, { timeout: SYNC_TIMEOUT }).toBe(100);
+});


### PR DESCRIPTION
## Problem
Fixes #99. 
Avatar WebRTC streams were playing at a continuous 100% volume regardless of the virtual distance between users on the canvas, breaking the spatial audio immersion.

## Root Cause
Spatial audio attenuation was only implemented locally within the `MediaPlayer` component, rather than abstracted for use by all media streams (like the `<video>` elements rendering remote peers in `Avatar.tsx`).

## Changes
| File | Summary |
| --- | --- |
| `spatialAudio.ts` | Extracted the Euclidean distance-to-volume mathematical logic into a shared utility function. |
| `MediaPlayer.tsx` | Refactored to import and use the new shared `spatialAudio` utility. |
| `Avatar.tsx` | Added a `requestAnimationFrame` loop to continuously compute target peer distance and attenuate `HTMLVideoElement.volume`. Exposes computed volume to a DOM `data-volume` property. |
| `types.ts` & `views.ts` | Expanded E2E DSL to support reading spatial `<audio>` volume metrics. |
| `spatial-audio.spec.ts` | Added comprehensive explicit E2E tests validating volume dropouts dynamically over distance. |

## Testing
- `just e2e-quick "test-spatial-audio"` passes.
- Full `just e2e-quick` regression suite runs completely with 95/95 passing tests.
